### PR TITLE
Add Support for x-gitlab-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Example config file with task definitions:
   },
   "keep":false,
   "logger": false,
-  "cmdshell":"/bin/bash"
+  "cmdshell":"/bin/bash",
+  "token":"my-gitlab-token"
 }
 ```
 The `*` matches any tasks.

--- a/gitlabhook.js
+++ b/gitlabhook.js
@@ -34,6 +34,7 @@ var GitLabHook = function(_options, _callback) {
   this.keep = (typeof options.keep === 'undefined') ? false : options.keep;
   this.logger = options.logger;
   this.callback = callback;
+  this.token = (typeof options.token === 'undefined') ? false : options.token;
 
   var active = false, tasks;
 
@@ -241,6 +242,13 @@ function serverHandler(req, res) {
       return reply(405, res);
   }
 
+  // validate gitlab-token
+  if (self.token && req.headers['x-gitlab-token'] != self.token) {
+      self.logger.error(Util.format('got invalid token from %s, returning 405',
+        remoteAddress));
+      failed = true;
+      return reply(400, res);
+  }
 }
 
 function getCmds(tasks, map, repo) {


### PR DESCRIPTION
Add Support for http-header "x-gitlab-token" to increase security of the webhook